### PR TITLE
refactored callback URLs to use an order_number parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 The `solidus_six_saferpay` engine adds checkout options for the Saferpay Payment Page ([Integration Guide](https://saferpay.github.io/sndbx/Integration_PP.html), [JSON API documentation](http://saferpay.github.io/jsonapi/#ChapterPaymentPage)) and the Saferpay Transaction ([Integration Guide](https://saferpay.github.io/sndbx/Integration_trx.html), [JSON API documentation](https://saferpay.github.io/sndbx/Integration_trx.html)).
 
+### Disclaimer
+This gem is built to be a general-purpose integration of the Six Saferpay payment interface. However due to lack of resources and because we are (as far as we know) the only users of this gem, we are only testing our use cases (PaymentPage). Therefore we can not guarantee that this will work in any other solidus shop. If you consider using this gem, please test everything thoroughly.
+
 ## Status
 Travis CI status: [![Build Status](https://travis-ci.org/fadendaten/solidus_six_saferpay.svg?branch=master)](https://travis-ci.org/fadendaten/solidus_six_saferpay)
 

--- a/app/controllers/spree/solidus_six_saferpay/checkout_controller.rb
+++ b/app/controllers/spree/solidus_six_saferpay/checkout_controller.rb
@@ -8,6 +8,10 @@ module Spree
 
 
         payment_method = Spree::PaymentMethod.find(params[:payment_method_id])
+        Spree::LogEntry.create(
+          source: @order,
+          details: "Initializing Spree::SixSaferpayPayment for PaymentMethod #{payment_method.id} (#{payment_method.name})"
+        )
         initialized_payment = initialize_payment(@order, payment_method)
 
         if initialized_payment.success?
@@ -22,6 +26,11 @@ module Spree
         order_number = params[:order_number]
         @order = Spree::Order.find_by(number: order_number)
 
+        Spree::LogEntry.create(
+          source: @order,
+          details: "A payment for this order was completed successfully by the user. We are now trying to handle this payment."
+        )
+
         if @order.nil?
           @redirect_path = spree.cart_path
           render :iframe_breakout_redirect, layout: false
@@ -32,6 +41,10 @@ module Spree
         # authorization. This could happen if a user presses the back button
         # after completing an order.
         if @order.completed?
+          Spree::LogEntry.create(
+            source: @order,
+            details: "Order already completed. Redirecting to cart path."
+          )
           @redirect_path = spree.cart_path
           render :iframe_breakout_redirect, layout: false
           return
@@ -40,8 +53,17 @@ module Spree
         saferpay_payment = Spree::SixSaferpayPayment.where(order_id: @order.id).order(:created_at).last
 
         if saferpay_payment.nil?
+          Spree::LogEntry.create(
+            source: @order,
+            details: "Could not find a Spree::SixSaferpayPayment for this order."
+          )
           raise Spree::Core::GatewayError, t('.saferpay_payment_not_found')
         end
+
+        Spree::LogEntry.create(
+          source: @order,
+          details: "The payment #{saferpay_payment.id} is being authorized and then processed."
+        )
 
         # NOTE: PaymentPage payments are authorized directly. Instead, we
         # perform an ASSERT here to gather the necessary details.
@@ -58,13 +80,25 @@ module Spree
 
           processed_authorization = process_authorization(saferpay_payment)
           if processed_authorization.success?
+            Spree::LogEntry.create(
+              source: @order,
+              details: "The Spree::SixSaferpayPayment #{saferpay_payment.id} was processed successfully. Now handling processing success."
+            )
             handle_payment_processing_success
           else
+            Spree::LogEntry.create(
+              source: @order,
+              details: "The Spree::SixSaferpayPayment #{saferpay_payment.id} failed to process. User was informed with: #{processed_authorization.user_message}"
+            )
             flash[:error] = processed_authorization.user_message
           end
 
         else
           payment_inquiry = inquire_payment(saferpay_payment)
+          Spree::LogEntry.create(
+            source: @order,
+            details: "The Spree::SixSaferpayPayment #{saferpay_payment.id} could not be authorized. User was informed with: #{payment_inquiry.user_message}"
+          )
           flash[:error] = payment_inquiry.user_message
         end
 
@@ -84,11 +118,21 @@ module Spree
 
         saferpay_payment = Spree::SixSaferpayPayment.where(order_id: @order.id).order(:created_at).last
 
+
         if saferpay_payment
           payment_inquiry = inquire_payment(saferpay_payment)
+          Spree::LogEntry.create(
+            source: @order,
+            details: "FAIL: The Spree::SixSaferpayPayment #{saferpay_payment.id} failed. User was informed with: #{user_message}"
+          )
           flash[:error] = payment_inquiry.user_message
         else
-          flash[:error] = I18n.t(:general_error, scope: [:solidus_six_saferpay, :errors])
+          user_message = I18n.t(:general_error, scope: [:solidus_six_saferpay, :errors])
+          Spree::LogEntry.create(
+            source: @order,
+            details: "FAIL: A payment for this order failed, but we can not find it. User was informed with #{user_message}",
+          )
+          flash[:error] = user_message
         end
 
         @redirect_path = order_checkout_path(:payment)

--- a/app/controllers/spree/solidus_six_saferpay/checkout_controller.rb
+++ b/app/controllers/spree/solidus_six_saferpay/checkout_controller.rb
@@ -3,8 +3,6 @@ module Spree
     class CheckoutController < StoreController
 
       def init
-        # loading the order is not shared between actions because the success
-        # action must break out of the iframe
         @order = current_order
         redirect_to(spree.cart_path) && return unless @order
 
@@ -21,9 +19,9 @@ module Spree
       end
 
       def success
-        # loading the order is not shared between actions because the success
-        # action must break out of the iframe
-        @order = current_order
+        order_number = params[:order_number]
+        @order = Spree::Order.find_by(number: order_number)
+
         if @order.nil?
           @redirect_path = spree.cart_path
           render :iframe_breakout_redirect, layout: false
@@ -75,9 +73,9 @@ module Spree
       end
 
       def fail
-        # loading the order is not shared between actions because the success
-        # action must break out of the iframe
-        @order = current_order
+        order_number = params[:order_number]
+        @order = Spree::Order.find_by(number: order_number)
+
         if @order.nil?
           @redirect_path = spree.cart_path
           render :iframe_breakout_redirect, layout: false

--- a/app/services/spree/solidus_six_saferpay/inquire_payment.rb
+++ b/app/services/spree/solidus_six_saferpay/inquire_payment.rb
@@ -21,7 +21,7 @@ module Spree
         if inquiry.success?
           saferpay_payment.update_attributes(response_hash: inquiry.api_response.to_h)
         else
-          saferpay_payment.update_attributes(response_hash: response_hash.merge(error: "#{inquiry.error_name}: #{inquiry.error_message}"))
+          saferpay_payment.update_attributes(response_hash: saferpay_payment.response_hash.merge(error: "#{inquiry.error_name}"))
           general_error = I18n.t(:general_error, scope: [:solidus_six_saferpay, :errors])
           specific_error = I18n.t(inquiry.error_name, scope: [:six_saferpay, :error_names])
           @user_message = "#{general_error}: #{specific_error}"

--- a/app/services/spree/solidus_six_saferpay/inquire_payment.rb
+++ b/app/services/spree/solidus_six_saferpay/inquire_payment.rb
@@ -21,6 +21,7 @@ module Spree
         if inquiry.success?
           saferpay_payment.update_attributes(response_hash: inquiry.api_response.to_h)
         else
+          saferpay_payment.update_attributes(response_hash: response_hash.merge(error: "#{inquiry.error_name}: #{inquiry.error_message}"))
           general_error = I18n.t(:general_error, scope: [:solidus_six_saferpay, :errors])
           specific_error = I18n.t(inquiry.error_name, scope: [:six_saferpay, :error_names])
           @user_message = "#{general_error}: #{specific_error}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,14 +4,14 @@ Spree::Core::Engine.routes.draw do
   namespace :solidus_six_saferpay do
     namespace :payment_page do
       get :init, controller: :checkout, defaults: { format: :json }
-      get :success, controller: :checkout
-      get :fail, controller: :checkout
+      get 'success/:order_number', to: 'checkout#success', as: :success
+      get 'fail/:order_number', to: 'checkout#fail', as: :fail
     end
 
     namespace :transaction do
       get :init, controller: :checkout, defaults: { format: :json }
-      get :success, controller: :checkout
-      get :fail, controller: :checkout
+      get 'success/:order_number', to: 'checkout#success', as: :success
+      get 'fail/:order_number', to: 'checkout#fail', as: :fail
     end
   end
 end

--- a/lib/solidus_six_saferpay/gateway.rb
+++ b/lib/solidus_six_saferpay/gateway.rb
@@ -5,9 +5,6 @@ module SolidusSixSaferpay
 
     def initialize(options = {})
       SixSaferpay.configure do |config|
-        config.success_url = options.fetch(:success_url)
-        config.fail_url = options.fetch(:fail_url)
-
         # Allow config via ENV for static values
         config.customer_id = options.fetch(:customer_id) { ENV.fetch('SIX_SAFERPAY_CUSTOMER_ID') }
         config.terminal_id = options.fetch(:terminal_id) { ENV.fetch('SIX_SAFERPAY_TERMINAL_ID') }
@@ -156,12 +153,16 @@ module SolidusSixSaferpay
       )
       payer = SixSaferpay::Payer.new(language_code: I18n.locale, billing_address: billing_address, delivery_address: delivery_address)
 
-      params = { payment: payment, payer: payer }
+      params = { payment: payment, payer: payer, return_urls: return_urls(order) }
 
       six_payment_methods = payment_method.enabled_payment_methods
       params.merge!(payment_methods: six_payment_methods) unless six_payment_methods.blank?
 
       params
+    end
+
+    def return_urls(order)
+      raise NotImplementedError, "Must be imnplemented in PaymentPageGateway or TransactionGateway"
     end
 
     def response(success, message, api_response, options = {})

--- a/lib/solidus_six_saferpay/gateway.rb
+++ b/lib/solidus_six_saferpay/gateway.rb
@@ -162,7 +162,7 @@ module SolidusSixSaferpay
     end
 
     def return_urls(order)
-      raise NotImplementedError, "Must be imnplemented in PaymentPageGateway or TransactionGateway"
+      raise NotImplementedError, "Must be implemented in PaymentPageGateway or TransactionGateway"
     end
 
     def response(success, message, api_response, options = {})

--- a/lib/solidus_six_saferpay/payment_page_gateway.rb
+++ b/lib/solidus_six_saferpay/payment_page_gateway.rb
@@ -1,15 +1,6 @@
 module SolidusSixSaferpay
   class PaymentPageGateway < Gateway
 
-    def initialize(options = {})
-      super(
-        options.merge(
-          success_url: url_helpers.solidus_six_saferpay_payment_page_success_url,
-          fail_url: url_helpers.solidus_six_saferpay_payment_page_fail_url
-        )
-      )
-    end
-
     def inquire(saferpay_payment, options = {})
       inquire_response = perform_assert_request(saferpay_payment, options)
 
@@ -45,6 +36,14 @@ module SolidusSixSaferpay
 
     def interface_initialize_object(order, payment_method)
       SixSaferpay::SixPaymentPage::Initialize.new(interface_initialize_params(order, payment_method))
+    end
+
+    def return_urls(order)
+      SixSaferpay::ReturnUrls.new(
+        success: url_helpers.solidus_six_saferpay_payment_page_success_url(order.number),
+        fd_fail: url_helpers.solidus_six_saferpay_payment_page_fail_url(order.number),
+        fd_abort: url_helpers.solidus_six_saferpay_payment_page_fail_url(order.number)
+      )
     end
 
     def perform_assert_request(saferpay_payment, options = {})

--- a/lib/solidus_six_saferpay/transaction_gateway.rb
+++ b/lib/solidus_six_saferpay/transaction_gateway.rb
@@ -1,15 +1,6 @@
 module SolidusSixSaferpay
   class TransactionGateway < Gateway
 
-    def initialize(options = {})
-      super(
-        options.merge(
-          success_url: url_helpers.solidus_six_saferpay_transaction_success_url,
-          fail_url: url_helpers.solidus_six_saferpay_transaction_fail_url
-        )
-      )
-    end
-
     def inquire(saferpay_payment, options = {})
       transaction_inquire = SixSaferpay::SixTransaction::Inquire.new(transaction_reference: saferpay_payment.transaction_id)
       inquire_response = SixSaferpay::Client.post(transaction_inquire)
@@ -42,6 +33,14 @@ module SolidusSixSaferpay
 
     def interface_initialize_object(order, payment_method)
       SixSaferpay::SixTransaction::Initialize.new(interface_initialize_params(order, payment_method))
+    end
+
+    def return_urls(order)
+      SixSaferpay::ReturnUrls.new(
+        success: url_helpers.solidus_six_saferpay_transaction_success_url(order.number),
+        fd_fail: url_helpers.solidus_six_saferpay_transaction_fail_url(order.number),
+        fd_abort: url_helpers.solidus_six_saferpay_transaction_fail_url(order.number)
+      )
     end
   end
 end

--- a/spec/services/spree/solidus_six_saferpay/inquire_payment_page_payment_spec.rb
+++ b/spec/services/spree/solidus_six_saferpay/inquire_payment_page_payment_spec.rb
@@ -44,8 +44,8 @@ module Spree
             expect(subject).to be_success
           end
 
-          it 'does not update the response hash' do
-            expect { subject.call }.not_to change { payment.response_hash }
+          it 'adds the error message to the response hash' do
+            expect { subject.call }.to change { payment.response_hash }.from({}).to({error: error_name})
           end
 
           it 'sets the user message according to the api error code' do

--- a/spec/services/spree/solidus_six_saferpay/inquire_transaction_payment_spec.rb
+++ b/spec/services/spree/solidus_six_saferpay/inquire_transaction_payment_spec.rb
@@ -44,8 +44,8 @@ module Spree
             expect(subject).to be_success
           end
 
-          it 'does not update the response hash' do
-            expect { subject.call }.not_to change { payment.response_hash }
+          it 'adds the error message to the response hash' do
+            expect { subject.call }.to change { payment.response_hash }.from({}).to({error: error_name})
           end
 
           it 'sets the user message according to the api error code' do

--- a/spec/solidus_six_saferpay/gateway_spec.rb
+++ b/spec/solidus_six_saferpay/gateway_spec.rb
@@ -7,15 +7,11 @@ module SolidusSixSaferpay
     let(:terminal_id) { 'TERMINAL_ID' }
     let(:username) { 'USERNAME' }
     let(:password) { 'PASSWORD' }
-    let(:success_url) { '/api/endpoints/success' }
-    let(:fail_url) { '/api/endpoints/fail' }
     let(:base_url) { 'https://test.saferpay-api-host.test' }
     let(:css_url) { '/custom/css/url' }
 
     let(:gateway) do
       described_class.new(
-        success_url: success_url,
-        fail_url: fail_url,
         customer_id: customer_id,
         terminal_id: terminal_id,
         username: username,
@@ -29,8 +25,6 @@ module SolidusSixSaferpay
       
       it 'configures the API client' do
         gateway = described_class.new(
-          success_url: success_url,
-          fail_url: fail_url,
           customer_id: customer_id,
           terminal_id: terminal_id,
           username: username,
@@ -45,8 +39,6 @@ module SolidusSixSaferpay
         expect(config.terminal_id).to eq(terminal_id)
         expect(config.username).to eq(username)
         expect(config.password).to eq(password)
-        expect(config.success_url).to eq(success_url)
-        expect(config.fail_url).to eq(fail_url)
         expect(config.base_url).to eq(base_url)
         expect(config.css_url).to eq(css_url)
       end
@@ -63,10 +55,7 @@ module SolidusSixSaferpay
         end
         
         it 'falls back to ENV vars' do
-          gateway = described_class.new(
-            success_url: success_url,
-            fail_url: fail_url
-          )
+          gateway = described_class.new
 
           config = SixSaferpay.config
 
@@ -74,8 +63,6 @@ module SolidusSixSaferpay
           expect(config.terminal_id).to eq(terminal_id)
           expect(config.username).to eq(username)
           expect(config.password).to eq(password)
-          expect(config.success_url).to eq(success_url)
-          expect(config.fail_url).to eq(fail_url)
           expect(config.base_url).to eq(base_url)
           expect(config.css_url).to eq(css_url)
         end

--- a/spec/solidus_six_saferpay/payment_page_gateway_spec.rb
+++ b/spec/solidus_six_saferpay/payment_page_gateway_spec.rb
@@ -8,8 +8,6 @@ module SolidusSixSaferpay
     let(:terminal_id) { 'TERMINAL_ID' }
     let(:username) { 'USERNAME' }
     let(:password) { 'PASSWORD' }
-    let(:success_url) { '/api/endpoints/success' }
-    let(:fail_url) { '/api/endpoints/fail' }
     let(:base_url) { 'https://test.saferpay-api-host.test' }
     let(:css_url) { '/custom/css/url' }
 
@@ -36,17 +34,6 @@ module SolidusSixSaferpay
       allow(ENV).to receive(:fetch).with('SIX_SAFERPAY_PASSWORD').and_return(password)
       allow(ENV).to receive(:fetch).with('SIX_SAFERPAY_BASE_URL').and_return(base_url)
       allow(ENV).to receive(:fetch).with('SIX_SAFERPAY_CSS_URL').and_return(css_url)
-    end
-
-    describe '#initialize' do
-      it 'configures the API client with correct urls by default' do
-        described_class.new
-
-        config = SixSaferpay.config
-
-        expect(config.success_url).to eq(solidus_six_saferpay_payment_page_success_url)
-        expect(config.fail_url).to eq(solidus_six_saferpay_payment_page_fail_url)
-      end
     end
 
     describe '#initialize_payment' do
@@ -111,11 +98,19 @@ module SolidusSixSaferpay
           delivery_address: saferpay_shipping_address
         )
       end
+      let(:return_urls) do
+        instance_double("SixSaferpay::ReturnUrls",
+          success: solidus_six_saferpay_payment_page_success_url(order),
+          fd_fail: solidus_six_saferpay_payment_page_fail_url(order),
+          fd_abort: solidus_six_saferpay_payment_page_fail_url(order),
+         )
+      end
 
       let(:initialize_params) do
         {
           payment: saferpay_payment,
-          payer: saferpay_payer
+          payer: saferpay_payer,
+          return_urls: return_urls
         }
       end
 
@@ -184,6 +179,13 @@ module SolidusSixSaferpay
           billing_address: saferpay_billing_address,
           delivery_address: saferpay_shipping_address
         ).and_return(saferpay_payer)
+
+        # mock return_urls
+        expect(SixSaferpay::ReturnUrls).to receive(:new).with(
+          success: solidus_six_saferpay_payment_page_success_url(order),
+          fd_fail: solidus_six_saferpay_payment_page_fail_url(order),
+          fd_abort: solidus_six_saferpay_payment_page_fail_url(order),
+        ).and_return(return_urls)
 
         expect(SixSaferpay::SixPaymentPage::Initialize).to receive(:new).with(initialize_params).and_return(saferpay_initialize)
 


### PR DESCRIPTION
This let's us identify the order without relying on things like
`current_order` or `current_user`, which is cookie-based and can fail in
certain circumstances.